### PR TITLE
Accept TextNodes in show method

### DIFF
--- a/src/juicy-highlight.html
+++ b/src/juicy-highlight.html
@@ -184,7 +184,7 @@
             if (Array.isArray(elements)) {
                 this.focused = elements;
             }
-            else if (elements && elements.length) {
+            else if (elements instanceof NodeList) {
                 this.focused = Array.prototype.slice.call(elements); //convert NodeList to Array
             }
             else if (elements) {


### PR DESCRIPTION
Before it was transforming TextNode to array of characters.

@warpech do you recall any usage for Array-like objects other than NodesList that should be converted to an array?